### PR TITLE
Remove unused dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,8 +17,7 @@
   },
   "dependencies": {
     "adler-32": "~1.3.0",
-    "crc-32": "~1.2.0",
-    "printj": "~1.3.0"
+    "crc-32": "~1.2.0"
   },
   "devDependencies": {
     "@sheetjs/uglify-js": "~2.7.3",


### PR DESCRIPTION
The printj package is used only by the cli package.